### PR TITLE
Fixed bug where if the user presses 'cancel' within WorldPay the order still get marked as paid

### DIFF
--- a/Nop.Plugin.Payments.WorldPay/Controllers/PaymentWorldPayController.cs
+++ b/Nop.Plugin.Payments.WorldPay/Controllers/PaymentWorldPayController.cs
@@ -151,9 +151,9 @@ namespace Nop.Plugin.Payments.WorldPay.Controllers
             });
             _orderService.UpdateOrder(order);
 
-            /*if (transStatus.ToLower() != "y")
-                return  Content(string.Format("The transaction status received from WorldPay ({0}) for the order {1} was declined.", transStatus, orderId));
-            */
+            if (transStatus.ToLower() != "y")
+                    return "<html><head><meta http-equiv=\"refresh\" content=\"0; url=" + _webHelper.GetStoreLocation(false) + "/checkout\"><title>Some title here</title></head><body><h2><WPDISPLAY ITEM=banner></h2><br /><h2>Object moved to <a href=\"" + _webHelper.GetStoreLocation(false) + "/checkout/completed/" + order.Id + "\">here</a>.</h2></body></html>";
+
 
             if (_orderProcessingService.CanMarkOrderAsPaid(order))
             {

--- a/Nop.Plugin.Payments.WorldPay/Controllers/PaymentWorldPayController.cs
+++ b/Nop.Plugin.Payments.WorldPay/Controllers/PaymentWorldPayController.cs
@@ -152,7 +152,7 @@ namespace Nop.Plugin.Payments.WorldPay.Controllers
             _orderService.UpdateOrder(order);
 
             if (transStatus.ToLower() != "y")
-                    return "<html><head><meta http-equiv=\"refresh\" content=\"0; url=" + _webHelper.GetStoreLocation(false) + "/checkout\"><title>Some title here</title></head><body><h2><WPDISPLAY ITEM=banner></h2><br /><h2>Object moved to <a href=\"" + _webHelper.GetStoreLocation(false) + "/checkout/completed/" + order.Id + "\">here</a>.</h2></body></html>";
+                    return "<html><head><meta http-equiv=\"refresh\" content=\"0; url=" + _webHelper.GetStoreLocation(false) + "/checkout\"><title>Some title here</title></head><body><h2><WPDISPLAY ITEM=banner></h2><br /><h2>Object moved to <a href=\"" + _webHelper.GetStoreLocation(false) + "/checkout\">here</a>.</h2></body></html>";
 
 
             if (_orderProcessingService.CanMarkOrderAsPaid(order))


### PR DESCRIPTION
Fixed bug where if the user presses 'cancel' within WorldPay the order still get marked as paid and processed by redirecting any unsuccessful orders back to the /checkout URL.
